### PR TITLE
Skip parsing the '~A data section for mnemonics

### DIFF
--- a/lascheck/reader.py
+++ b/lascheck/reader.py
@@ -431,30 +431,31 @@ def parse_header_section(
     if not mnemonic_case == "preserve":
         section.mnemonic_transforms = True
 
-    for i in range(len(sectdict["lines"])):
-        line = sectdict["lines"][i]
-        j = sectdict["line_nos"][i]
-        if not line:
-            continue
-        try:
-            values = read_line(line)
-        except:
-            message = 'line {} (section {}): "{}"'.format(
-                # traceback.format_exc().splitlines()[-1].strip('\n'),
-                j,
-                title,
-                line,
-            )
-            if ignore_header_errors:
-                logger.warning(message)
+    if not title.startswith('~A'):
+        for i in range(len(sectdict["lines"])):
+            line = sectdict["lines"][i]
+            j = sectdict["line_nos"][i]
+            if not line:
+                continue
+            try:
+                values = read_line(line)
+            except:
+                message = 'line {} (section {}): "{}"'.format(
+                    # traceback.format_exc().splitlines()[-1].strip('\n'),
+                    j,
+                    title,
+                    line,
+                )
+                if ignore_header_errors:
+                    logger.warning(message)
+                else:
+                    raise exceptions.LASHeaderError(message)
             else:
-                raise exceptions.LASHeaderError(message)
-        else:
-            if mnemonic_case == "upper":
-                values["name"] = values["name"].upper()
-            elif mnemonic_case == "lower":
-                values["name"] = values["name"].lower()
-            section.append(parser(**values))
+                if mnemonic_case == "upper":
+                    values["name"] = values["name"].upper()
+                elif mnemonic_case == "lower":
+                    values["name"] = values["name"].lower()
+                section.append(parser(**values))
     return section
 
 


### PR DESCRIPTION
This pull request is an efficiency improvement. When the section is the ~ASCII data section, it will skip the section parsing for metadata mnemonics.   I found this issue when running a test.las file with a large data section.  It was taking a long time.  This change removed reduced the processing time.

All tests pass locally.

This change is in the lascheck/reader.py::parse_header_section().   I put in an identical pull request with Lasio: https://github.com/kinverarity1/lasio/pull/371.   Will Lascheck stay in sync with Lasio  or will it be a separate code line going forward?

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC