### PR TITLE
Remove passing "~A" to parse_header_section()

### DIFF
--- a/lascheck/las.py
+++ b/lascheck/las.py
@@ -145,6 +145,20 @@ class LASFile(object):
             for key in drop:
                 self.raw_sections.pop(key)
 
+        def add_special_section(pattern, name, **sect_kws):
+            raw_section = self.match_raw_section(pattern)
+            drop = []
+            if raw_section:
+                self.sections[name] = "\n".join(raw_section["lines"])
+                drop.append(raw_section["title"])
+            else:
+                logger.warning(
+                    "Header section %s regexp=%s was not found." % (name, pattern)
+                )
+
+            for key in drop:
+                self.raw_sections.pop(key)
+
         add_section(
             "~V",
             "Version",
@@ -235,23 +249,10 @@ class LASFile(object):
             self.duplicate_p_section = True
             self.non_conformities.append("Duplicate p section")
 
-        s = self.match_raw_section("~O")
 
-        add_section(
-            "~A",
-            "Ascii",
-            version=version,
-            ignore_header_errors=ignore_header_errors,
-            mnemonic_case=mnemonic_case,
-        )
+        add_special_section("~A", "Ascii")
 
-        drop = []
-        if s:
-            self.sections["Other"] = "\n".join(s["lines"])
-            drop.append(s["title"])
-        for key in drop:
-            self.raw_sections.pop(key)
-
+        add_special_section("~O", "Other")
         if self.match_raw_section("~O"):
             self.duplicate_o_section = True
             self.non_conformities.append("Duplicate o section")

--- a/lascheck/reader.py
+++ b/lascheck/reader.py
@@ -431,31 +431,30 @@ def parse_header_section(
     if not mnemonic_case == "preserve":
         section.mnemonic_transforms = True
 
-    if not title.startswith('~A'):
-        for i in range(len(sectdict["lines"])):
-            line = sectdict["lines"][i]
-            j = sectdict["line_nos"][i]
-            if not line:
-                continue
-            try:
-                values = read_line(line)
-            except:
-                message = 'line {} (section {}): "{}"'.format(
-                    # traceback.format_exc().splitlines()[-1].strip('\n'),
-                    j,
-                    title,
-                    line,
-                )
-                if ignore_header_errors:
-                    logger.warning(message)
-                else:
-                    raise exceptions.LASHeaderError(message)
+    for i in range(len(sectdict["lines"])):
+        line = sectdict["lines"][i]
+        j = sectdict["line_nos"][i]
+        if not line:
+            continue
+        try:
+            values = read_line(line)
+        except:
+            message = 'line {} (section {}): "{}"'.format(
+                # traceback.format_exc().splitlines()[-1].strip('\n'),
+                j,
+                title,
+                line,
+            )
+            if ignore_header_errors:
+                logger.warning(message)
             else:
-                if mnemonic_case == "upper":
-                    values["name"] = values["name"].upper()
-                elif mnemonic_case == "lower":
-                    values["name"] = values["name"].lower()
-                section.append(parser(**values))
+                raise exceptions.LASHeaderError(message)
+        else:
+            if mnemonic_case == "upper":
+                values["name"] = values["name"].upper()
+            elif mnemonic_case == "lower":
+                values["name"] = values["name"].lower()
+            section.append(parser(**values))
     return section
 
 


### PR DESCRIPTION
- Revert/remove checking for "~A" in parse_header_section().  (Pull-Request #3)
- Add add_special_section() to process/track "~A" and "~O" sections.

This pull-request keeps  processing of the "~A" section in the las.py::read() function (and its new sub function `las.py::read()add_special_section()`). This should improve maintainability.

`add_special_section()` is a simpler variation on `add_section()`  that can be used for registering sections that don't follow the specific metadata format.  The "~O"  section is changed to register with add_special_section.

All tests pass.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC



