### PR TITLE
Add reporting multiple sections with blank line

### DIFF
--- a/lascheck/las.py
+++ b/lascheck/las.py
@@ -65,7 +65,7 @@ class LASFile(object):
         self.sections_after_a_section = False
         self.v_section_first = False
         self.blank_line_in_section = False
-        self.section_with_blank_line = ""
+        self.sections_with_blank_line = []
 
         default_items = defaults.get_default_items()
         if not (file_ref is None):
@@ -122,7 +122,7 @@ class LASFile(object):
 
         try:
             self.raw_sections, self.sections_after_a_section, self.v_section_first, self.blank_line_in_section, \
-            self.section_with_blank_line = \
+            self.sections_with_blank_line = \
                 reader.read_file_contents(file_obj, regexp_subs, value_null_subs, ignore_data=ignore_data)
         finally:
             if hasattr(file_obj, "close"):
@@ -709,7 +709,9 @@ class LASFile(object):
         if ('Curves' in self.sections) and (spec.ValidDepthDividedByStep.check(self)) is False:
             self.non_conformities.append("Depth divided by step is not valid")
         if (spec.BlankLineInSection.check(self)) is False:
-            self.non_conformities.append("Section {} having blank line".format(self.section_with_blank_line))
+            for section in self.sections_with_blank_line:
+                self.non_conformities.append(
+                    "Section {} having blank line".format(section))
         if self.sections_after_a_section:
             self.non_conformities.append("Sections after ~a section")
         return self.non_conformities

--- a/lascheck/reader.py
+++ b/lascheck/reader.py
@@ -281,7 +281,7 @@ def read_file_contents(file_obj, regexp_subs, value_null_subs, ignore_data=False
     sections_after_a_section = False
     v_section_first = False
     blank_line_in_section = False
-    section_with_blank_line = ""
+    sections_with_blank_line = [] 
 
     for i, line in enumerate(file_obj):
         line = line.strip()
@@ -289,6 +289,8 @@ def read_file_contents(file_obj, regexp_subs, value_null_subs, ignore_data=False
             if section_exists:
                 blank_line_in_section = True
                 section_with_blank_line = sect_title_line.split()[0]
+                sections_with_blank_line.append(
+                    section_with_blank_line)
             continue
         if data_section_read:
             sections_after_a_section = True
@@ -329,7 +331,7 @@ def read_file_contents(file_obj, regexp_subs, value_null_subs, ignore_data=False
         "lines": sect_lines
     }
 
-    return sections, sections_after_a_section, v_section_first, blank_line_in_section, section_with_blank_line
+    return sections, sections_after_a_section, v_section_first, blank_line_in_section, sections_with_blank_line
 
 
 def get_substitutions(read_policy, null_policy):

--- a/tests/test_conformity.py
+++ b/tests/test_conformity.py
@@ -233,11 +233,12 @@ def test_check_blank_line_in_parameter_section():
     assert las.get_non_conformities() == ["Section ~A having blank line"]
 
 
-# todo: this should report both a curve and a parameter blank line
 def test_check_blank_lines_in_two_section():
     las = lascheck.read(readfromexamples("blank_line_in_two_sections.las"))
     assert not spec.BlankLineInSection.check(las)
-    assert las.get_non_conformities() == ["Section ~PARAMETER having blank line"]
+    assert las.get_non_conformities() == [
+        "Section ~CURVE having blank line",
+        "Section ~PARAMETER having blank line"]
 
 
 def test_check_conforming_positive():


### PR DESCRIPTION
#### Description:

Previously only the last section with a blank line was reported.  This change enable all sections with one or more blank lines to be reported.  

#### Test Results:

The test `tests/test_conformity.py::test_check_blank_lines_in_two_section` is updated to verify this change.
All 37 test pass.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC
