### PR TITLE
Exclude las files from GitHub Language Stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.las -linguist-detectable


### PR DESCRIPTION
#### Description:

This commit updates how GitHub displays LasCheck's language breakout by
excluding the *.las files which get mis-identified as Lasso files.
See: https://github.com/github/linguist#detectable

#### Tests:

These are results from running gitHub-linguist on local development machine:
see:
https://github.com/github/linguist#installation

Before this branch:
```
51.42%  Python
48.58%  Lasso
```

After this branch:
```
100.00% Python
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC